### PR TITLE
Fix keys 'key' and 'secret' to be in 'credentials' array for clients

### DIFF
--- a/DependencyInjection/PlatinumPixsAwsExtension.php
+++ b/DependencyInjection/PlatinumPixsAwsExtension.php
@@ -35,6 +35,18 @@ class PlatinumPixsAwsExtension extends Extension
 
         foreach ($configs as $name => $config) {
             $definition = new Definition('%platinum_pixs_aws.class%');
+            $credentials = array();
+
+            foreach (array('key', 'secret') as $k) {
+                if (isset($config[$k])) {
+                    $credentials[$k] = $config[$k];
+                    unset($config[$k]);
+                }
+            }
+
+            if (!empty($credentials) && !isset($config['credentials'])) {
+                $config['credentials'] =  $credentials;
+            }
 
             $definition->setArguments(array($config))->addTag('platinum_pixs_aws');
 


### PR DESCRIPTION
I noticed the documentation is off on how to specify credentials (was getting error because if you do not provide credentials to `Sdk` properly then it is assumed you are on EC2 and the code queries for the correct credentials), so I fixed loading credentials to be set in the `'credentials'` array which only gets made if there is not already one.

The documentation would have to say to use something like this to work:

```
platinum_pixs_aws:
    base:
        region: %aws_default_region%
        credentials:
            key: %aws_key%
            secret: %aws_secret%
```

This PR fixes loading credentials as currently documented, which I think is a nice shortcut. You can explicitly load as above without issue but it is not necessary.
